### PR TITLE
fix: Reduce paymaster funding and add balance check for deployment script

### DIFF
--- a/script/DeploySocialVerification.s.sol
+++ b/script/DeploySocialVerification.s.sol
@@ -57,13 +57,15 @@ contract DeploySocialVerification is Script {
         // Check if deployer has sufficient balance
         require(
             deployer.balance >= INITIAL_PAYMASTER_FUNDING,
-            string(abi.encodePacked(
-                "Insufficient balance for paymaster funding. Required: ",
-                vm.toString(INITIAL_PAYMASTER_FUNDING / 1e18),
-                " ETH, Available: ",
-                vm.toString(deployer.balance / 1e18),
-                " ETH"
-            ))
+            string(
+                abi.encodePacked(
+                    "Insufficient balance for paymaster funding. Required: ",
+                    vm.toString(INITIAL_PAYMASTER_FUNDING / 1e18),
+                    " ETH, Available: ",
+                    vm.toString(deployer.balance / 1e18),
+                    " ETH"
+                )
+            )
         );
 
         payable(address(paymaster)).transfer(INITIAL_PAYMASTER_FUNDING);

--- a/script/DeploySocialVerification.s.sol
+++ b/script/DeploySocialVerification.s.sol
@@ -14,7 +14,7 @@ import "../src/eip7702/EIP7702Paymaster.sol";
 contract DeploySocialVerification is Script {
     // Configuration
     address public constant RISC_ZERO_VERIFIER_KEY = 0x1234567890123456789012345678901234567890; // Replace with actual key
-    uint256 public constant INITIAL_PAYMASTER_FUNDING = 2 ether;
+    uint256 public constant INITIAL_PAYMASTER_FUNDING = 0.5 ether;
 
     // Deployed contract addresses
     SocialAccountRegistry public socialRegistry;
@@ -53,6 +53,19 @@ contract DeploySocialVerification is Script {
 
         // Step 5: Fund the paymaster
         console.log("\n5. Funding paymaster...");
+
+        // Check if deployer has sufficient balance
+        require(
+            deployer.balance >= INITIAL_PAYMASTER_FUNDING,
+            string(abi.encodePacked(
+                "Insufficient balance for paymaster funding. Required: ",
+                vm.toString(INITIAL_PAYMASTER_FUNDING / 1e18),
+                " ETH, Available: ",
+                vm.toString(deployer.balance / 1e18),
+                " ETH"
+            ))
+        );
+
         payable(address(paymaster)).transfer(INITIAL_PAYMASTER_FUNDING);
         console.log("Paymaster funded with:", INITIAL_PAYMASTER_FUNDING / 1e18, "ETH");
 


### PR DESCRIPTION
## Problem

The `DeploySocialVerification.s.sol` deployment script was failing with `Error: script failed: <empty revert data>` during the paymaster funding step. The root cause was:

- Script attempted to transfer 2 ETH to the paymaster
- Deployer account only had 1 ETH balance
- This caused an `OutOfFunds` error with empty revert data

## Solution

This PR fixes the deployment script by:

1. **Reducing Initial Paymaster Funding**: Changed `INITIAL_PAYMASTER_FUNDING` from `2 ether` to `0.5 ether`
2. **Adding Balance Check**: Added a require statement with clear error message to check deployer balance before funding

## Changes

- Reduced `INITIAL_PAYMASTER_FUNDING` from 2 ETH to 0.5 ETH
- Added balance validation with descriptive error message
- Prevents `OutOfFunds` errors during deployment

## Testing

✅ Successfully deployed all contracts on Sepolia testnet:
- SocialAccountRegistry: `0x31B602db32404AB15a41075774ccAF66918edA8c`
- RiscZeroSocialVerifier: `0xB9CEBA74F39Dc46D11e950B938513f909707Ddc1`
- EIP7702Paymaster: `0xCa8E82DAE06041dE1f5186af8B3b48d2c3430E8d`

✅ All contracts verified on Etherscan
✅ Paymaster successfully funded with 0.5 ETH

## Impact

- Fixes deployment script reliability
- Provides clear error messages for insufficient balance
- Maintains sufficient paymaster funding for testing and operations

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author